### PR TITLE
IPMI: add support for GUI test and make one example

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -411,7 +411,8 @@ sub init_consoles {
                 hostname => get_required_var('SUT_IP'),
                 password => $testapi::password,
                 user     => 'root',
-                serial   => 'mkfifo /dev/sshserial; tail -f /dev/sshserial'
+                serial   => 'mkfifo /dev/sshserial; tail -f /dev/sshserial',
+                gui      => 1
             });
     }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -804,18 +804,18 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/reboot_and_wait_up_normal";
     }
     else {
-        load_boot_tests();
-        if (get_var("AUTOYAST")) {
-            loadtest "autoyast/installation";
-            loadtest "virt_autotest/reboot_and_wait_up_normal";
-        }
-        else {
-            load_inst_tests();
+#        load_boot_tests();
+#        if (get_var("AUTOYAST")) {
+#            loadtest "autoyast/installation";
+#            loadtest "virt_autotest/reboot_and_wait_up_normal";
+#        }
+#        else {
+#            load_inst_tests();
             loadtest "virt_autotest/login_console";
-        }
-        loadtest "virt_autotest/install_package";
-        loadtest "virt_autotest/update_package";
-        loadtest "virt_autotest/reboot_and_wait_up_normal";
+#        }
+#        loadtest "virt_autotest/install_package";
+#        loadtest "virt_autotest/update_package";
+#        loadtest "virt_autotest/reboot_and_wait_up_normal";
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
         loadtest "virt_autotest/guest_installation_run";
@@ -864,6 +864,9 @@ elsif (get_var("VIRT_AUTOTEST")) {
     }
     elsif (get_var("VIRT_NEW_GUEST_MIGRATION_DESTINATION")) {
         loadtest "virt_autotest/guest_migration_dst";
+    }
+    elsif (get_var("GUI_TEST_EXAMPLE")) {
+        loadtest "virt_autotest/virt_manager_example";
     }
 }
 elsif (get_var("PERF_KERNEL")) {

--- a/tests/virt_autotest/virt_manager_example.pm
+++ b/tests/virt_autotest/virt_manager_example.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm and xen support fully
+# Maintainer: alice <xlai@suse.com>
+
+package virt_manager_example;
+use base "y2logsstep";
+use strict;
+use warnings;
+use File::Basename;
+use testapi;
+use Utils::Backends 'use_ssh_serial_console';
+use ipmi_backend_utils;
+
+sub run {
+    my $self = shift;
+
+    use_ssh_serial_console;
+    #GUI test of virt-manger
+    assert_script_run("virsh list --all");
+    type_string "Will start GUI test\n";
+    save_screenshot;
+    type_string "virt-manager\n";
+    wait_still_screen;
+    save_screenshot;
+    sleep 10;
+    save_screenshot;
+
+    assert_and_click "new-vm-button";
+    wait_still_screen;
+    save_screenshot;
+
+    assert_and_click "forward";
+    wait_still_screen;
+    save_screenshot;
+
+    assert_and_click "cancel";
+    wait_still_screen;
+    save_screenshot;
+
+    assert_and_click "close";
+    wait_still_screen;
+    save_screenshot;
+
+    type_string "\n";
+    assert_script_run("echo 'back to terminal after GUI test'");
+    save_screenshot;
+     
+}
+
+sub post_fail_hook {
+    return 0;
+}
+1;
+


### PR DESCRIPTION
Make necessary support for GUI testing on ipmi workers, and make a simple GUI test example of virt-manager.

Links: http://10.67.18.220/tests/573